### PR TITLE
Add Quarto, LaTeX, pak, R-INLA, targets, tarchetypes, repana; remove pkgr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG R_VERSION=4.4.3
 ARG NAMESPACE_FROM=rocker
 FROM ${NAMESPACE_FROM}/verse:${R_VERSION}
 
-# Install Java, JAGS, sf dependencies and renv
+# Install Java, JAGS, sf dependencies
 RUN apt-get update && apt-get install -y \
     default-jdk \
     jags \
@@ -13,11 +13,10 @@ RUN apt-get update && apt-get install -y \
     libgeos-dev \
     libproj-dev \
     libgsl0-dev \
- && rm -rf /var/lib/apt/lists/* \
- && Rscript -e "install.packages('renv')"
+ && rm -rf /var/lib/apt/lists/*
 
- # Install chromium and dependencies
- RUN apt-get update && \
+# Install chromium and dependencies
+RUN apt-get update && \
     apt-get install -y wget gnupg2 software-properties-common ca-certificates --no-install-recommends && \
     add-apt-repository -y ppa:xtradeb/apps && \
     apt-get update && \
@@ -29,14 +28,31 @@ RUN apt-get update && \
     apt-get install -y gh --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Remove rocker's dummy texlive-local equivs package so apt can manage texlive,
+# then install a full LaTeX base for Quarto (PDF, XeLaTeX, LuaLaTeX, bibliography)
+RUN dpkg -r texlive-local \
+ && apt-get update && apt-get install -y \
+    texlive-latex-base \
+    texlive-latex-recommended \
+    texlive-latex-extra \
+    texlive-fonts-recommended \
+    texlive-xetex \
+    texlive-luatex \
+    texlive-plain-generic \
+    texlive-bibtex-extra \
+    biber \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install R packages: bootstrap pak, then use pak for everything else
+# INLA repo added for its pre-built amd64/arm64 binaries
+RUN Rscript -e "install.packages('pak', repos = sprintf('https://r-lib.github.io/p/pak/stable/%s/%s/%s', .Platform\$pkgType, R.Version()\$os, R.Version()\$arch))" \
+ && Rscript -e "pak::repo_add(INLA = 'https://inla.r-inla-download.org/R/stable'); pak::pkg_install(c('renv', 'INLA', 'repana', 'quarto', 'targets', 'tarchetypes'))"
+
 # Copy rstudio-server config file
 COPY rserver.conf /etc/rstudio/rserver.conf
-    
+
 # Customized entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-
-
-
 
 CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ ARG R_VERSION=4.4.3
 ARG NAMESPACE_FROM=rocker
 FROM ${NAMESPACE_FROM}/verse:${R_VERSION}
 
-# Set pkgr version
-ENV PKGR_VERSION=3.1.2
-
-# Install Java, JAGS, pkgr, sf dependences and renv
+# Install Java, JAGS, sf dependencies and renv
 RUN apt-get update && apt-get install -y \
     default-jdk \
     jags \
@@ -16,11 +13,6 @@ RUN apt-get update && apt-get install -y \
     libgeos-dev \
     libproj-dev \
     libgsl0-dev \
- && curl -L https://github.com/metrumresearchgroup/pkgr/releases/download/v${PKGR_VERSION}/pkgr_${PKGR_VERSION}_linux_amd64.tar.gz -o /tmp/pkgr.tar.gz \
- && tar -xzf /tmp/pkgr.tar.gz pkgr \
- && mv pkgr /usr/local/bin/pkgr \
- && chmod +x /usr/local/bin/pkgr \
- && rm /tmp/pkgr.tar.gz \
  && rm -rf /var/lib/apt/lists/* \
  && Rscript -e "install.packages('renv')"
 

--- a/README.md
+++ b/README.md
@@ -6,72 +6,92 @@ This repository provides a Docker container for reproducible R analyses, based o
 
 - Based on `rocker/verse`, with `R_VERSION` passed as a build argument.
 - Adds the following to the base image:
-  - **Java** (default in the Ubuntu-based `rocker/verse` container)
-  - **JAGS** (default in the Ubuntu-based `rocker/verse` container)
-  - **[pkgr](https://github.com/r-hub/pkgr)** for package management (default version: 3.1.2)
-- Sets `R_LIBS` to include home as the first library path.
-- Includes the appropriate `renv` package version matching `R_VERSION`.
+  - **Java**
+  - **JAGS**
+  - **[renv](https://rstudio.github.io/renv/)** for project-level package reproducibility
+  - **[pak](https://pak.r-lib.org/)** for fast and reliable package installation
+  - **[R-INLA](https://www.r-inla.org/)** for Bayesian inference using INLA
+  - **[targets](https://docs.ropensci.org/targets/) + [tarchetypes](https://docs.ropensci.org/tarchetypes/)** for pipeline-based analysis
+  - **[repana](https://cran.r-project.org/package=repana)** for reproducible analysis workflows
+  - **[quarto](https://quarto.org/)** R package (Quarto CLI is bundled in `rocker/verse`)
+  - **Full LaTeX base** (texlive-latex-base, texlive-xetex, texlive-luatex, biber, and more) for Quarto PDF rendering
+  - **Chromium** for headless browser support
+  - **GitHub CLI (gh)**
+- Sets `R_LIBS` to include the user home as the first library path.
 - Creates an RStudio user with a **randomly generated password** by default.
-- In addition, it can create a custom user by providing the `USER_NAME` and `USER_PASSWORD` 
-  environment variables at runtime, which should be the user for the container
+- Supports a custom user via `USER_NAME` and `USER_PASSWORD` environment variables at runtime.
 
 ## Image Creation
 
-Container can be customized using build-time and runtime environment variables.  
-Refer to the Dockerfile and entrypoint script for more details.  
-Use the `build_image` utility script to simplify the process:
+The tag is automatically determined by reading the latest tag from Docker Hub and incrementing it.
+The `--namespacefrom` defaults to `jjserver` but can be overridden.
 
 ```bash
-# /build_image R_VERSION TAG
-./build_image.sh --rver 4.4.3 --tag 1 --namespacefrom rocker --namespaceto <your namespace>
+./build_image.sh --rver 4.6.0 --namespaceto <your namespace>
 ```
 
-This will create the image <your namespace>/`r_analysis-4_4_3:1`, based on the latest verse:4.4.3`
-Please note that rocker does not produce ARM64 images, so you may need to build use your own build
-of ARM64 and this is why namespacefrom can be change.
+This will create `<your namespace>/r_analysis-4_6_0:<next tag>` and also tag it as `latest`.
 
-## Container Deployment 
-Container can be run using Docker Compose an .env file (please note password is plain in .env)
-The yml file should be adapted to ensure container name is unique and the host port is not conflicting 
-other services in the running environment.
-The volumen for projects have the correct path
+> **Note:** `rocker` does not produce ARM64 images. If you need ARM64 support, build your own
+> base image and pass it via `--namespacefrom`.
+
+## Running R from the Command Line
+
+To use R from the container without installing it locally, add this function to your `~/.zshrc` or `~/.bashrc`:
 
 ```bash
-# Create the directory where to setup the project
-<path to script>/create_r_project.sh --container <your namespace>/r_analysis-4_4_3 --tag 1
+R() {
+  local image="${R_DOCKER_IMAGE:-jjserver/r_analysis-4_6_0:latest}"
+  docker run --rm -it \
+    -v "$(pwd):/home/rstudio/project" \
+    -w /home/rstudio/project \
+    "$image" R "$@"
+}
+```
+
+After reloading your shell (`source ~/.zshrc`), typing `R` will launch R inside the container
+with the current directory mounted as the working directory.
+
+## Container Deployment
+
+The container can be run using Docker Compose with an `.env` file (note: password is stored in plain text in `.env`).
+The `docker-compose.yml` should be adapted to ensure the container name is unique and the host port
+does not conflict with other services. The volume path for projects should be set correctly.
+
+```bash
+<path to script>/create_r_project.sh --container <your namespace>/r_analysis-4_6_0 --tag <tag>
 ```
 
 ### File structure
 ```
-r-analysis-proyect/
-├── .gitignore               # To not include in Git in case added to github
+r-analysis-project/
+├── .gitignore               # Prevents accidental Git inclusion
 ├── .env                     # Contains USER_NAME and USER_PASSWORD
 ├── docker-compose.yml       # For running the container
 └── projects/                # Volume for persistent analysis work
     └── (your R project files go here)
 ```
+
 ### `.gitignore` file:
 ```
-DS_STORE
+.DS_Store
 .env
 # Each project must have its own git repository
 projects
 ```
 
 ### `.env` file:
-
 ```env
 USER_NAME=myuser
 USER_PASSWORD=mysecretpass
 ```
 
 ### `docker-compose.yml`:
-
 ```yaml
 services:
   rstudio:
-    image: r_analysis_4.4.3:1
-    container_name: r_analysis_ana
+    image: <your namespace>/r_analysis-4_6_0:latest
+    container_name: r_analysis_myproject
     ports:
       - "8787:8787"
     environment:

--- a/build_image.sh
+++ b/build_image.sh
@@ -52,22 +52,19 @@ fi
 R_VERSION_FORMATTED="${R_VERSION//./_}"
 REPO_NAME="r_analysis-${R_VERSION_FORMATTED}"
 
-# Read latest semver tag from Docker Hub and increment patch
+# Read latest integer tag from Docker Hub and increment
 echo "Fetching latest tag for ${NAMESPACE_TO}/${REPO_NAME} from Docker Hub..."
 LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/${NAMESPACE_TO}/${REPO_NAME}/tags/?page_size=100" \
   | jq -r '.results[].name' 2>/dev/null \
-  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-  | sort -V \
+  | grep -E '^[0-9]+$' \
+  | sort -n \
   | tail -1)
 
 if [ -z "$LATEST_TAG" ]; then
-  echo "No existing semver tag found — starting at 1.0.0"
-  NEW_TAG="1.0.0"
+  echo "No existing tag found — starting at 1"
+  NEW_TAG="1"
 else
-  MAJOR=$(echo "$LATEST_TAG" | cut -d. -f1)
-  MINOR=$(echo "$LATEST_TAG" | cut -d. -f2)
-  PATCH=$(echo "$LATEST_TAG" | cut -d. -f3)
-  NEW_TAG="${MAJOR}.${MINOR}.$((PATCH + 1))"
+  NEW_TAG="$((LATEST_TAG + 1))"
   echo "Latest tag: ${LATEST_TAG} → new tag: ${NEW_TAG}"
 fi
 

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,28 +1,24 @@
 #!/bin/bash
 # Usage: ./build_image.sh \
 #          --rver <R_VERSION> \
-#          --tag <TAG> \
-#          --namespacefrom <SOURCE_NAMESPACE> \
-#          --namespaceto <TARGET_NAMESPACE>
+#          --namespaceto <TARGET_NAMESPACE> \
+#          [--namespacefrom <SOURCE_NAMESPACE>]
+#
+# Tag is automatically determined from the latest Docker Hub tag for the image.
 # by JJAV 20250520
 
 set -e
 
- # Default values
+# Default values
 R_VERSION=""
-TAG=""
-NAMESPACE_FROM=""
+NAMESPACE_FROM="jjserver"
 NAMESPACE_TO=""
 
- # Parse arguments
+# Parse arguments
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --rver)
       R_VERSION="$2"
-      shift
-      ;;
-    --tag)
-      TAG="$2"
       shift
       ;;
     --namespacefrom)
@@ -35,27 +31,46 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     *)
       echo "Unknown parameter passed: $1"
-      echo "Usage: $0 --rver <R_VERSION> --tag <TAG> --namespacefrom <SOURCE_NAMESPACE> [--namespaceto <TARGET_NAMESPACE>]"
-      echo "  --rver: R version to use (e.g., 4.4.3)"
-      echo "  --tag: Tag for the resulting Docker image (e.g., latest)"
-      echo "  --namespacefrom: Namespace used inside the Docker build (passed as build arg)"
-      echo "  --namespaceto: Namespace used when tagging/pushing image"
+      echo "Usage: $0 --rver <R_VERSION> --namespaceto <TARGET_NAMESPACE> [--namespacefrom <SOURCE_NAMESPACE>]"
+      echo "  --rver:          R version to use (e.g., 4.4.3)"
+      echo "  --namespaceto:   Namespace used when tagging/pushing image"
+      echo "  --namespacefrom: Source of verse namespace (default: jjserver)"
       exit 1
       ;;
   esac
   shift
 done
 
-if [ -z "$R_VERSION" ] || [ -z "$TAG" ] || [ -z "$NAMESPACE_TO" ]; then
-  echo "Usage: $0 --rver <R_VERSION> --tag <TAG> --namespacefrom <SOURCE_NAMESPACE> --namespaceto <TARGET_NAMESPACE>"
-  echo "  --rver: R version to use (e.g., 4.4.3)"
-  echo "  --tag: Tag for the resulting Docker image (e.g., latest)"
-  echo "  --namespacefrom: Source of verse. Namespace  passed as build arg"
-  echo "  --namespaceto: Namespace used when tagging/pushing image (required)"
+if [ -z "$R_VERSION" ] || [ -z "$NAMESPACE_TO" ]; then
+  echo "Usage: $0 --rver <R_VERSION> --namespaceto <TARGET_NAMESPACE> [--namespacefrom <SOURCE_NAMESPACE>]"
+  echo "  --rver:          R version to use (e.g., 4.4.3)"
+  echo "  --namespaceto:   Namespace used when tagging/pushing image (required)"
+  echo "  --namespacefrom: Source of verse namespace (default: jjserver)"
   exit 1
 fi
 
 R_VERSION_FORMATTED="${R_VERSION//./_}"
+REPO_NAME="r_analysis-${R_VERSION_FORMATTED}"
+
+# Read latest semver tag from Docker Hub and increment patch
+echo "Fetching latest tag for ${NAMESPACE_TO}/${REPO_NAME} from Docker Hub..."
+LATEST_TAG=$(curl -s "https://hub.docker.com/v2/repositories/${NAMESPACE_TO}/${REPO_NAME}/tags/?page_size=100" \
+  | jq -r '.results[].name' 2>/dev/null \
+  | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -1)
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "No existing semver tag found — starting at 1.0.0"
+  NEW_TAG="1.0.0"
+else
+  MAJOR=$(echo "$LATEST_TAG" | cut -d. -f1)
+  MINOR=$(echo "$LATEST_TAG" | cut -d. -f2)
+  PATCH=$(echo "$LATEST_TAG" | cut -d. -f3)
+  NEW_TAG="${MAJOR}.${MINOR}.$((PATCH + 1))"
+  echo "Latest tag: ${LATEST_TAG} → new tag: ${NEW_TAG}"
+fi
+
 CREATED_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # Ensure a multiarch builder is configured
@@ -71,15 +86,15 @@ docker buildx build \
   --build-arg R_VERSION="${R_VERSION}" \
   --build-arg NAMESPACE_FROM="${NAMESPACE_FROM}" \
   --label org.opencontainers.image.title="R Analysis Container" \
-  --label org.opencontainers.image.version="${TAG}" \
+  --label org.opencontainers.image.version="${NEW_TAG}" \
   --label org.opencontainers.image.created="${CREATED_DATE}" \
-  --label org.opencontainers.image.description="Docker image for reproducible R analysis with rocker/verse, Java, JAGS, and pkgr." \
+  --label org.opencontainers.image.description="Docker image for reproducible R analysis with rocker/verse, Java, JAGS, renv, pak, Quarto/LaTeX, R-INLA, targets, tarchetypes, repana, chromium, and gh CLI." \
   --label org.opencontainers.image.licenses="MIT" \
   --label org.opencontainers.image.source="https://github.com/johnaponte/docker_r_analysis.git" \
   --label org.opencontainers.image.documentation="https://github.com/johnaponte/docker_r_analysis/blob/main/README.md" \
-  -t "${NAMESPACE_TO}/r_analysis-${R_VERSION_FORMATTED}:${TAG}" \
-  -t "${NAMESPACE_TO}/r_analysis-${R_VERSION_FORMATTED}:latest" \
+  -t "${NAMESPACE_TO}/${REPO_NAME}:${NEW_TAG}" \
+  -t "${NAMESPACE_TO}/${REPO_NAME}:latest" \
   --push \
   .
 
-echo "Image ${IMAGE_NAME} built successfully with metadata."
+echo "Image ${NAMESPACE_TO}/${REPO_NAME}:${NEW_TAG} built and pushed successfully."


### PR DESCRIPTION
## Summary

- Remove pkgr support (no longer useful)
- Add full LaTeX base for Quarto PDF rendering (removes rocker's dummy `texlive-local` equivs package first)
- Add R packages: `pak`, `renv`, `R-INLA`, `quarto`, `targets`, `tarchetypes`, `repana`
- Consolidate all R package installs into a single Dockerfile layer
- Auto-detect and increment Docker Hub tags in `build_image.sh` (no more manual `--tag`); default `--namespacefrom` to `jjserver`
- Update README to reflect all changes and document the `R()` shell function for running R via Docker

## Test plan

- [x] Build image locally: `docker build --build-arg R_VERSION=4.6.0 --build-arg NAMESPACE_FROM=jjserver -t r_analysis_test .`
- [x] Run R interactively: `docker run --rm -it r_analysis_test R`
- [x] Verify packages load: `library(INLA)`, `library(targets)`, `library(quarto)`, `library(repana)`
- [x] Test multi-arch build via `build_image.sh`
- [x] Confirm tag auto-increment reads correctly from Docker Hub
